### PR TITLE
Add full NodeJs tool set

### DIFF
--- a/Pack.ps1
+++ b/Pack.ps1
@@ -18,5 +18,7 @@ if (!(Test-Path $targetDir)) { $null = mkdir $targetDir }
 
 $Properties = "src=$PSScriptRoot\src;common=$PSScriptRoot\obj\$Version"
 
-nuget pack $PSScriptRoot\src\Node.js.redist.nuspec -BasePath $LayoutRoot -OutputDirectory $targetDir -Version $Version -Properties $Properties
-nuget pack $PSScriptRoot\src\Node.js.redist.symbols.nuspec -BasePath $LayoutRootSymbols -OutputDirectory $targetDir -Version $Version -Properties $Properties
+$nugetPath = "$PSScriptRoot\nuget.exe"
+
+. $nugetPath pack $PSScriptRoot\src\Node.js.redist.withtools.nuspec -BasePath $LayoutRoot -OutputDirectory $targetDir -Version $Version -Properties $Properties
+# . $nugetPath pack $PSScriptRoot\src\Node.js.redist.symbols.nuspec -BasePath $LayoutRootSymbols -OutputDirectory $targetDir -Version $Version -Properties $Properties

--- a/src/Node.js.redist.withtools.nuspec
+++ b/src/Node.js.redist.withtools.nuspec
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>Node.js.redist</id>
+        <id>Node.js.redist.withtools</id>
         <version>$version$</version>
-        <title>Node.js redist</title>
+        <title>Node.js redist with tools</title>
         <authors>Node.js Foundation</authors>
-        <owners>AArnott</owners>
+        <owners>lemming104, AArnott</owners>
         <license type="file">LICENSE</license>
-        <projectUrl>https://github.com/AArnott/Node.js.redist</projectUrl>
+        <projectUrl>https://github.com/lemming104/Node.js.redist</projectUrl>
         <icon>icon.png</icon>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js' package ecosystem, npm, is the largest ecosystem of open source libraries in the world.</description>


### PR DESCRIPTION
Instead of copying just the node binary, also the files needed for NPM, NPX, and Corepack.