### PR TITLE
Drop linux/osx executables from symbols package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./Build.ps1 -Version ${{ inputs.version || '20.18.2' }} -Verbose
-        name: Building node.js.redist packages
+        name: 🏗️ Building node.js.redist packages
       - uses: actions/upload-artifact@v4
         with:
           path: bin

--- a/Get-NuGetTool.ps1
+++ b/Get-NuGetTool.ps1
@@ -6,7 +6,7 @@
 #>
 Param(
 	[Parameter()]
-	[string]$NuGetVersion = '6.4.0'
+	[string]$NuGetVersion = '6.12.2'
 )
 
 $command = Get-Command nuget -ErrorAction SilentlyContinue

--- a/Restore.ps1
+++ b/Restore.ps1
@@ -75,13 +75,15 @@ Function Get-NetworkFile {
 }
 
 Function Get-NixNode($os, $arch, $osBrand) {
+	if (!$osBrand) { $osBrand = $os }
+	Write-Host "Acquiring node.js for $osBrand $arch"
+
 	$tgzPath = Get-NetworkFile -Uri $DistRootUri/node-v$Version-$os-$arch.tar.gz -OutDir "$PSScriptRoot\obj"
 	$tarName = [IO.Path]::GetFileNameWithoutExtension($tgzPath)
 	$tarPath = Join-Path $PSScriptRoot\obj $tarName
 	$null = & $unzipTool -y -o"$PSScriptRoot\obj" e $tgzPath $tarName
 	$null = & $unzipTool -y -o"$PSScriptRoot\obj" e $tarPath "node-v$Version-$os-$arch\bin\node"
 
-	if (!$osBrand) { $osBrand = $os }
 	$targetDir = "$LayoutRoot\tools\$osBrand-$arch"
 	if (!(Test-Path $targetDir)) {
 		$null = mkdir $targetDir
@@ -98,6 +100,7 @@ Function Get-NixNode($os, $arch, $osBrand) {
 }
 
 Function Get-WinNode($arch) {
+	Write-Host "Acquiring node.js for Windows $arch"
 	$nodePath = Get-NetworkFile -Uri https://nodejs.org/dist/v$Version/win-$arch/node.exe -OutDir "$PSScriptRoot\obj\win-$arch-$Version"
 	$targetDir = "$LayoutRoot\tools\win-$arch"
 	if (!(Test-Path $targetDir)) {
@@ -117,9 +120,9 @@ Function Get-WinNodePdb($arch) {
 	$targetDir = "$LayoutRootSymbols\tools\win-$arch"
 	$zipDir = "$PSScriptRoot\obj\win-$arch-$Version"
 	if (Test-Path $targetDir\node.pdb) {
-		Write-Verbose "Skipped node symbols for win-$arch"
+		Write-Verbose "Skipped node symbols for win-$arch because they are already present."
 	}
- else {
+	else {
 		Write-Verbose "Downloading node symbols for win-$arch..."
 		$zipPath = Get-NetworkFile -Uri https://nodejs.org/dist/v$Version/win-$arch/node_pdb.zip -OutDir "$PSScriptRoot\obj\win-$arch-$Version"
 		if (!(Test-Path $zipDir)) { $null = mkdir $zipDir }

--- a/Restore.ps1
+++ b/Restore.ps1
@@ -89,13 +89,7 @@ Function Get-NixNode($os, $arch, $osBrand) {
 		$null = mkdir $targetDir
 	}
 
-	$targetDirSymbols = "$LayoutRootSymbols\tools\$osBrand-$arch"
-	if (!(Test-Path $targetDirSymbols)) {
-		$null = mkdir $targetDirSymbols
-	}
-
 	Copy-Item $PSScriptRoot\obj\node $targetDir
-	Copy-Item $PSScriptRoot\obj\node $targetDirSymbols
 	Remove-Item $PSScriptRoot\obj\node
 }
 
@@ -107,13 +101,7 @@ Function Get-WinNode($arch) {
 		$null = mkdir $targetDir
 	}
 
-	$targetDirSymbols = "$LayoutRootSymbols\tools\win-$arch"
-	if (!(Test-Path $targetDirSymbols)) {
-		$null = mkdir $targetDirSymbols
-	}
-
 	Copy-Item $nodePath $targetDir
-	Copy-Item $nodePath $targetDirSymbols
 }
 
 Function Get-WinNodePdb($arch) {
@@ -132,7 +120,7 @@ Function Get-WinNodePdb($arch) {
 			$null = mkdir $targetDir
 		}
 
-		Copy-Item $zipDir\node.pdb $targetDir
+		Copy-Item $zipDir\node.pdb,$zipDir\node.exe $targetDir
 	}
 }
 

--- a/src/Node.js.redist.nuspec
+++ b/src/Node.js.redist.nuspec
@@ -15,9 +15,11 @@
 		<releaseNotes></releaseNotes>
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
+		<readme>README.md</readme>
 	</metadata>
 	<files>
 		<file src="**" target="/" />
+		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />
 	</files>

--- a/src/Node.js.redist.symbols.nuspec
+++ b/src/Node.js.redist.symbols.nuspec
@@ -3,7 +3,7 @@
 	<metadata>
 		<id>Node.js.redist.symbols</id>
 		<version>$version$</version>
-		<title>Node.js redist.symbols</title>
+		<title>Node.js symbols redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -15,9 +15,11 @@
 		<releaseNotes></releaseNotes>
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
+		<readme>README.md</readme>
 	</metadata>
 	<files>
 		<file src="**" target="" />
+		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />
 	</files>

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,10 @@
+# Node.js.redist
+
+This set of packages contains the node.js executable and debugging symbols necessary to run .js scripts on any desktop OS.
+
+The package version is based on the Node.js version that they contain.
+
+These packages bring in binaries applicable to every desktop OS and architecture via package dependencies:
+
+- `Node.js.redist` brings in the node.js executables
+- `Node.js.redist.symbols` brings in the debugger symbols for the executables.


### PR DESCRIPTION
Also add a README file to the packages and bump the nuget.exe version.