### PR TITLE
Split large packages into smaller ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
           name: Packages
         name: 📢 Publish artifacts
 
+      - run: ./Test.ps1 -Version ${{ inputs.version || '20.18.2' }} -Verbose
+        name: 🧪 Test packages
+
       - name: 🚀 Push NuGet packages
         run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ secrets.NUGET_API_KEY }}'
         if: success() && inputs.publish

--- a/Pack.ps1
+++ b/Pack.ps1
@@ -24,5 +24,17 @@ $Properties = "src=$PSScriptRoot\src;common=$PSScriptRoot\obj\$Version"
 
 $nugetTool = & "$PSScriptRoot\Get-NuGetTool.ps1"
 
-& $nugetTool pack $PSScriptRoot\src\Node.js.redist.nuspec -BasePath $LayoutRoot -OutputDirectory $targetDir -Version $Version -Properties $Properties
+'win','linux','osx' |% {
+	Write-Host "Packing binary packages for $_"
+	& $nugetTool pack $PSScriptRoot\src\Node.js.redist.$_.nuspec  -BasePath $LayoutRoot\$_ -OutputDirectory $targetDir -Version $Version -Properties $Properties
+}
+
+Write-Host "Packing symbols for Windows"
+'x86','x64','arm64' |% {
+	& $nugetTool pack $PSScriptRoot\src\Node.js.redist.symbols.win-$_.nuspec -BasePath $LayoutRootSymbols\win -OutputDirectory $targetDir -Version $Version -Properties $Properties
+}
+& $nugetTool pack $PSScriptRoot\src\Node.js.redist.symbols.win.nuspec -BasePath $LayoutRootSymbols\win -OutputDirectory $targetDir -Version $Version -Properties $Properties
+
+Write-Host "Packing top-level packages"
+& $nugetTool pack $PSScriptRoot\src\Node.js.redist.nuspec         -BasePath $LayoutRoot -OutputDirectory $targetDir -Version $Version -Properties $Properties
 & $nugetTool pack $PSScriptRoot\src\Node.js.redist.symbols.nuspec -BasePath $LayoutRootSymbols -OutputDirectory $targetDir -Version $Version -Properties $Properties

--- a/Restore.ps1
+++ b/Restore.ps1
@@ -84,7 +84,7 @@ Function Get-NixNode($os, $arch, $osBrand) {
 	$null = & $unzipTool -y -o"$PSScriptRoot\obj" e $tgzPath $tarName
 	$null = & $unzipTool -y -o"$PSScriptRoot\obj" e $tarPath "node-v$Version-$os-$arch\bin\node"
 
-	$targetDir = "$LayoutRoot\tools\$osBrand-$arch"
+	$targetDir = "$LayoutRoot\$osBrand\tools\$arch"
 	if (!(Test-Path $targetDir)) {
 		$null = mkdir $targetDir
 	}
@@ -96,7 +96,7 @@ Function Get-NixNode($os, $arch, $osBrand) {
 Function Get-WinNode($arch) {
 	Write-Host "Acquiring node.js for Windows $arch"
 	$nodePath = Get-NetworkFile -Uri https://nodejs.org/dist/v$Version/win-$arch/node.exe -OutDir "$PSScriptRoot\obj\win-$arch-$Version"
-	$targetDir = "$LayoutRoot\tools\win-$arch"
+	$targetDir = "$LayoutRoot\win\tools\$arch"
 	if (!(Test-Path $targetDir)) {
 		$null = mkdir $targetDir
 	}
@@ -105,7 +105,7 @@ Function Get-WinNode($arch) {
 }
 
 Function Get-WinNodePdb($arch) {
-	$targetDir = "$LayoutRootSymbols\tools\win-$arch"
+	$targetDir = "$LayoutRootSymbols\win\tools\$arch"
 	$zipDir = "$PSScriptRoot\obj\win-$arch-$Version"
 	if (Test-Path $targetDir\node.pdb) {
 		Write-Verbose "Skipped node symbols for win-$arch because they are already present."

--- a/Test.ps1
+++ b/Test.ps1
@@ -1,0 +1,35 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+	Tests the packages built by Pack.ps1 to ensure dependencies are all satisfied.
+.PARAMETER Version
+	The version of Node.js for which packages were built that should be tested.
+#>
+Param(
+	[Parameter(Mandatory = $true)]
+	[string]$Version
+)
+
+$TestOutputDir = Join-Path $PSScriptRoot obj tests
+$PackageSource = Join-Path $PSScriptRoot bin
+$nugetTool = & "$PSScriptRoot\Get-NuGetTool.ps1"
+
+# Make sure we start with a clean slate
+if (Test-Path $TestOutputDir) { Remove-Item -Path $TestOutputDir -Recurse -Force }
+New-Item -ItemType Directory -Path $TestOutputDir | Out-Null
+
+'Node.js.redist','Node.js.redist.symbols' |% {
+	& $nugetTool install $_ -OutputDirectory $TestOutputDir -Version $Version -Source $PackageSource
+}
+
+# Verify that the expected number of packages were brought down.
+$expectedCount = (Get-ChildItem $PSScriptRoot\src\*.nuspec).Length
+$actualCount = (Get-ChildItem $TestOutputDir\*).Length
+
+if ($expectedCount -ne $actualCount) {
+	Write-Error "Expected: $expectedCount. Actual: $actualCount"
+	exit 1
+}
+
+Write-Host "PASS"

--- a/src/Node.js.redist.linux.nuspec
+++ b/src/Node.js.redist.linux.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.linux</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for Linux redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -16,13 +16,9 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
-		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
-		</dependencies>
 	</metadata>
 	<files>
+		<file src="**" target="/" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/Node.js.redist.osx.nuspec
+++ b/src/Node.js.redist.osx.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.osx</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for MacOS redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -16,13 +16,9 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
-		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
-		</dependencies>
 	</metadata>
 	<files>
+		<file src="**" target="/" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/Node.js.redist.symbols.nuspec
+++ b/src/Node.js.redist.symbols.nuspec
@@ -16,9 +16,11 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
+		<dependencies>
+			<dependency id="Node.js.redist.symbols.win" version="$version$" />
+		</dependencies>
 	</metadata>
 	<files>
-		<file src="**" target="" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/Node.js.redist.symbols.win-arm64.nuspec
+++ b/src/Node.js.redist.symbols.win-arm64.nuspec
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.symbols.win-arm64</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for Windows arm64 symbols redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -16,13 +16,9 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
-		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
-		</dependencies>
 	</metadata>
 	<files>
+		<file src="tools\arm64\**" target="tools" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/Node.js.redist.symbols.win-x64.nuspec
+++ b/src/Node.js.redist.symbols.win-x64.nuspec
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.symbols.win-x64</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for Windows x64 symbols redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -16,13 +16,9 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
-		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
-		</dependencies>
 	</metadata>
 	<files>
+		<file src="tools\x64\**" target="tools" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/Node.js.redist.symbols.win-x86.nuspec
+++ b/src/Node.js.redist.symbols.win-x86.nuspec
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.symbols.win-x86</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for Windows x86 symbols redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -16,13 +16,9 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
-		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
-		</dependencies>
 	</metadata>
 	<files>
+		<file src="tools\x86\**" target="tools" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/Node.js.redist.symbols.win.nuspec
+++ b/src/Node.js.redist.symbols.win.nuspec
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.symbols.win</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for Windows symbols redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -17,9 +17,9 @@
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
 		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
+			<dependency id="Node.js.redist.symbols.win-x86" version="$version$" />
+			<dependency id="Node.js.redist.symbols.win-x64" version="$version$" />
+			<dependency id="Node.js.redist.symbols.win-arm64" version="$version$" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/src/Node.js.redist.win.nuspec
+++ b/src/Node.js.redist.win.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>Node.js.redist</id>
+		<id>Node.js.redist.win</id>
 		<version>$version$</version>
-		<title>Node.js redist</title>
+		<title>Node.js for Windows redist</title>
 		<authors>Node.js Foundation</authors>
 		<owners>AArnott</owners>
 		<license type="file">LICENSE</license>
@@ -16,13 +16,9 @@
 		<copyright>© 2015 Node.js Foundation</copyright>
 		<tags>node nodejs exe javascript runtime v8 server</tags>
 		<readme>README.md</readme>
-		<dependencies>
-			<dependency id="Node.js.redist.win" version="$version$" />
-			<dependency id="Node.js.redist.linux" version="$version$" />
-			<dependency id="Node.js.redist.osx" version="$version$" />
-		</dependencies>
 	</metadata>
 	<files>
+		<file src="**" target="/" />
 		<file src="$src$\README.md" target="README.md" />
 		<file src="$src$\icon.png" target="icon.png" />
 		<file src="$common$\LICENSE" target="LICENSE" />

--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,29 @@ This set of packages contains the node.js executable and debugging symbols neces
 
 The package version is based on the Node.js version that they contain.
 
+## Family of packages
+
+The matrix of OS and architecture requires several binaries to be packed.
+These binaries would lead a single NuGet package to exceed the nuget.org compressed size limit of 250MB.
+As a result, we have a couple of top-level packages which depend on other packages so that you can get all the binaries you want, whether that is for all OSs or just a subset.
+
+### Top-level packages
+
 These packages bring in binaries applicable to every desktop OS and architecture via package dependencies:
 
 - `Node.js.redist` brings in the node.js executables
 - `Node.js.redist.symbols` brings in the debugger symbols for the executables.
+
+### Per-platform packages
+
+The following packages are specific to a particular OS:
+
+Package ID | OS | Payload
+--|--|--
+`Node.js.redist.win` | Windows | Node.js executable binary
+`Node.js.redist.linux` | Linux | Node.js executable binary
+`Node.js.redist.osx` | MacOS | Node.js executable binary
+`Node.js.redist.symbols.win` | Windows | Dependencies on all `Node.js.redist.symbols.win-*` packages
+`Node.js.redist.symbols.win-x86` | Windows x86 | Node.js debugger symbols
+`Node.js.redist.symbols.win-x64` | Windows x64 | Node.js debugger symbols
+`Node.js.redist.symbols.win-arm64` | Windows arm64 | Node.js debugger symbols


### PR DESCRIPTION
Split monolithic packages

- The executable package is split into 3 OS packages.
- The symbols package is split into 3 packages by Windows architecture.

Closes #10